### PR TITLE
[CONTRAST-22221] Node_Modules Scanning

### DIFF
--- a/nvnr.js
+++ b/nvnr.js
@@ -6,7 +6,8 @@ const file_ts = require('./section.js').file_ts;
 const colors = require('./colors');
 const _ = require('lodash');
 const fs = require('fs');
-const { getInstalledPathSync } = require('get-installed-path');
+const GetInstallPath = require('get-installed-path');
+const path = require('path');
 
 function capitalizeFirstLetter(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
@@ -111,6 +112,7 @@ function banner() {
   console.log(colors.cyan('contrast nvnr (https://www.contrastsecurity.com/)'));
   console.log(reportDate);
   console.log();
+  console.log('**Common Modules List**');
 }
 
 function printSystemInfo() {
@@ -155,7 +157,7 @@ function printSection(sectionTitle, dependencies, devDependencies, search_map) {
     _.forIn(dependencies, (value, key) => {
       if (key.search(frameworkRegExp) !== -1) {
         section.addData(capitalizeFirstLetter(key), value);
-        let path = getInstalledPathSync(key, { local: true });
+        let path = GetInstallPath.getInstalledPathSync(key, { local: true });
         findModuleDeps(section, key, path);
       }
     });
@@ -163,7 +165,7 @@ function printSection(sectionTitle, dependencies, devDependencies, search_map) {
     _.forIn(devDependencies, (value, key) => {
       if (key.search(frameworkRegExp) !== -1) {
         section.addData(capitalizeFirstLetter(key), value);
-        let path = getInstalledPathSync(key, { local: true });
+        let path = GetInstallPath.getInstalledPathSync(key, { local: true });
         findModuleDeps(section, key, path);
       }
     });
@@ -213,6 +215,17 @@ function addons() {
   section.print();
 }
 
+function NodeModulesList() {
+  let nodeModulesPath = path.join(process.env.PWD, '/node_modules');
+  if (fs.existsSync(nodeModulesPath)) {
+    const section = new Section('Node Modules List');
+    fs.readdirSync(nodeModulesPath).forEach(file => {
+      section.addData('has', file);
+    });
+    section.print();
+  }
+}
+
 function main() {
   banner();
   printSystemInfo();
@@ -246,6 +259,7 @@ function main() {
       );
     }
     addons();
+    NodeModulesList();
 
     if (fs.existsSync(`nvnr-${file_ts}.txt`)) {
       console.log(`\nWrote nvnr-${file_ts}.txt to ${process.env.PWD}`);

--- a/nvnr.js
+++ b/nvnr.js
@@ -40,6 +40,8 @@ const testFrameworks = [
   'vows'
 ];
 
+const cms = ['apostrophe'];
+
 const daemonRunners = ['forever', 'nodemon', 'pm2', 'supervisor'];
 
 const taskRunners = ['ant', 'grunt', 'gulp'];
@@ -92,6 +94,7 @@ const miscModules = [
 
 const all_sections = {
   'HTTP Frameworks': httpFrameWorks,
+  CMS: cms,
   'Testing Frameworks': testFrameworks,
   'Daemon Runners': daemonRunners,
   'Task Runners': taskRunners,
@@ -166,9 +169,12 @@ function printSection(
       if (key.search(frameworkRegExp) !== -1) {
         let moduleName = capitalizeFirstLetter(key);
         section.addData(moduleName, value);
-        let path = GetInstallPath.getInstalledPathSync(moduleName, {
-          local: true
-        });
+        let path = GetInstallPath.getInstalledPathSync(
+          moduleName.toLowerCase(),
+          {
+            local: true
+          }
+        );
         findModuleDeps(section, moduleName, path);
         seen.push(moduleName);
       }
@@ -178,9 +184,12 @@ function printSection(
       if (key.search(frameworkRegExp) !== -1) {
         let moduleName = capitalizeFirstLetter(key);
         section.addData(moduleName, value);
-        let path = GetInstallPath.getInstalledPathSync(moduleName, {
-          local: true
-        });
+        let path = GetInstallPath.getInstalledPathSync(
+          moduleName.toLowerCase(),
+          {
+            local: true
+          }
+        );
         findModuleDeps(section, moduleName, path);
         seen.push(moduleName);
       }

--- a/nvnr.js
+++ b/nvnr.js
@@ -115,7 +115,6 @@ function banner() {
   console.log(colors.cyan('contrast nvnr (https://www.contrastsecurity.com/)'));
   console.log(reportDate);
   console.log();
-  console.log('**Common Modules List**');
 }
 
 function printSystemInfo() {


### PR DESCRIPTION
Added checking the /node_modules top level directory for dependencies names (in case the package.json looks like apostrophe's where it only includes itself to download deps)

Looks like this now because we can't grab the version without doing some more work, this maybe a good down the line feature?

Apostrophe: 
https://imgur.com/a/b9umm

Juice-Shop:
https://imgur.com/a/Sju62 (mixed finding in package.json and node modules)

 One thing I'm curious on is if we're getting too spammy, juice-shop's full output is:
[nvnr-1523319469069.txt](https://github.com/Contrast-Security-OSS/node-dvnr/files/1892379/nvnr-1523319469069.txt)


I'm worried that more complex apps will have a large amount of dependencies and produce a massive logfile that one of us would have to check for compatibility. I'm hoping to do some research to come up with a alternative/pairing solution to handle this case, but would love any thoughts.

